### PR TITLE
Add kibana-workflows universal skill (PoC)

### DIFF
--- a/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
+++ b/x-pack/platform/packages/shared/agent-builder/agent-builder-server/allow_lists.ts
@@ -126,6 +126,7 @@ export const AGENT_BUILDER_BUILTIN_SKILLS = [
   'ki-identification-management',
 
   // Platform – Workflows
+  'kibana-workflows',
   'workflow-authoring',
 
   // Security Solution

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/register_skills.ts
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/register_skills.ts
@@ -15,4 +15,5 @@ export const registerSkills = (agentBuilder: AgentBuilderPluginSetup) => {
   agentBuilder.skills.register(visualizationCreationSkill);
   agentBuilder.skills.register(graphCreationSkill);
   agentBuilder.skills.register(UniversalSkill.fromDirectory(path.join(__dirname, 'esql')));
+  agentBuilder.skills.register(UniversalSkill.fromDirectory(path.join(__dirname, 'workflows')));
 };

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/workflows/SKILL.md
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/workflows/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: kibana-workflows
+basePath: skills/platform/workflows
+description: >
+  Create, validate, test, run, and debug Elastic Workflow YAML definitions. Use when the user wants to turn natural
+  language into a Kibana workflow, fix workflow YAML, understand triggers or steps, or run a quick workflow test loop.
+experimental: true
+metadata:
+  author: workflows
+  version: "0.1.0"
+  visibility: internal
+---
+
+# Kibana Workflows
+
+Create and iterate on Elastic Workflow YAML definitions. Workflows are declarative automations that run inside Kibana:
+they can query Elasticsearch, transform data, branch, loop, call connectors, create cases, notify external systems, and
+invoke AI steps.
+
+This skill follows the universal skill pattern: workflow syntax and generation guidance live in markdown, and live
+validation/execution feedback comes from the `elastic` CLI.
+
+<!-- begin-partial: preamble -->
+
+## Environment Configuration
+
+This skill validates and runs workflows through the `elastic` CLI. Before running any operation, confirm the `elastic`
+CLI is installed and configured with a Kibana context.
+
+If the CLI is not available, ask the user to install or configure the [`elastic` CLI](https://github.com/elastic/cli)
+before continuing. Do not guess Kibana credentials or call workflow indices directly.
+
+This skill references workflow operations in shorthand form, for example `TEST workflow`, `CREATE workflow`, and
+`RUN workflow`. The [Operations](#operations) table maps each shorthand operation to the corresponding
+`elastic stack kb workflows ...` command.
+
+Verify the connection before changing anything:
+
+```bash
+elastic es info
+```
+
+If workflow APIs are hidden, enable the required Kibana settings for the target space:
+
+- `agentBuilder:experimentalFeatures`
+- `workflows:ui:enabled`
+
+<!-- end-partial: preamble -->
+
+## Guidelines
+
+1. **Start with the user's intent.** Identify the trigger, inputs, data sources, actions, and desired output before
+   writing YAML. If a required external dependency is unknown (for example a Slack connector ID), ask or create a safe
+   placeholder rather than inventing one.
+
+2. **Pick the smallest useful workflow.** Prefer a manual trigger for the first draft unless the user explicitly asks for
+   a scheduled or alert-driven workflow. Add scheduling, alert context, connectors, and destructive actions only when
+   they are part of the request.
+
+3. **Use the workflow YAML structure exactly.** Include `version: '1'`, a unique `name`, at least one trigger, and a
+   `steps` array. Use 2-space indentation. Step input parameters go under `with`; step configuration fields such as
+   `condition`, `steps`, `else`, `foreach`, `connector-id`, `if`, `timeout`, and `on-failure` live beside `with`.
+
+4. **Generate YAML from known workflow patterns.** Before writing unfamiliar step types or trigger shapes, read the
+   references:
+   - [Workflow YAML Reference](references/workflow_yaml_reference.md) - root structure, triggers, common step patterns,
+     Liquid usage, and lifecycle commands
+   - [Workflow Generation Tips](references/generation_tips.md) - critical syntax rules, common mistakes, and repair loops
+   - [Workflow Patterns](references/workflow_patterns.md) - natural-language request patterns mapped to workflow YAML
+   - [Demo Test Loop](references/demo_test_loop.md) - a repeatable prompt, YAML draft, and CLI command sequence
+
+5. **Prefer connector steps over raw HTTP.** For integrations such as Slack, Jira, PagerDuty, email, ServiceNow, and
+   Teams, use the connector name as the step `type` and set `connector-id`. Use raw `http` only when no connector exists
+   or the user explicitly asks for a raw API call.
+
+6. **Do not guess runtime paths.** Step outputs are referenced through `steps.<name>.output`. Never use
+   `steps.<name>.with.*` or `steps.<name>.<input_param>`. Trigger event data is `event`, never `trigger.event` or
+   `triggers.event`.
+
+7. **Validate or test-run quickly.** After generating YAML, run `TEST workflow` when possible. If the workflow must be
+   persisted first, run `CREATE workflow`, then `RUN workflow`, then inspect execution details and logs. Fix YAML based
+   on validation/runtime feedback and repeat.
+
+## Workflow YAML Quick Reference
+
+```yaml
+version: '1'
+name: Manual Hello Workflow
+description: Logs a hello message from a manual workflow
+enabled: true
+tags: ["demo", "workflow"]
+
+triggers:
+  - type: manual
+
+inputs:
+  properties:
+    name:
+      type: string
+      description: Name to greet
+      default: "world"
+
+steps:
+  - name: log_hello
+    type: console
+    with:
+      message: "Hello {{ inputs.name }}"
+```
+
+Every step supports common fields:
+
+```yaml
+- name: unique_step_name
+  type: step_type
+  with:
+    param: value
+  connector-id: connector-id-for-connector-steps
+  if: "steps.previous.output.ok"
+  timeout: "30s"
+  on-failure:
+    retry:
+      max-attempts: 3
+      delay: "5s"
+    fallback:
+      - name: handle_error
+        type: console
+        with:
+          message: "Step failed"
+    continue: true
+```
+
+Common built-in step types:
+
+| Step type | Use for |
+| --- | --- |
+| `console` | Debug logging during tests |
+| `elasticsearch.search` | Query Elasticsearch with Query DSL |
+| `elasticsearch.esql.query` | Query Elasticsearch with ES|QL |
+| `elasticsearch.bulk` | Bulk indexing |
+| `data.set` | Set values in workflow context |
+| `data.transform` | Transform data |
+| `if` | Branch on a KQL condition |
+| `foreach` | Loop over a collection |
+| `wait` | Pause execution |
+| `http` | Raw HTTP calls |
+| `ai.agent` | Invoke an Agent Builder agent |
+
+Connector-based step types use the connector type name, for example `slack`, `jira`, `email`, or `pagerduty`, with a
+`connector-id` field.
+
+## Generation Tips
+
+Use [Workflow Generation Tips](references/generation_tips.md) before authoring anything beyond a trivial manual workflow.
+The most common mistakes are:
+
+- Missing `version: '1'`
+- Invalid or guessed step type IDs
+- Putting step config inside `with`
+- Referencing `triggers.event` instead of `event`
+- Reading step inputs from `steps.<name>.with.*`
+- Using Liquid expressions in `if` step `condition`
+- Forgetting `connector-id` for connector steps
+- Creating alert-triggered workflows that assume manual runs also have `event.alerts`
+
+## Fast Test-Run Loop
+
+For a new workflow, keep the first loop small:
+
+1. Write the YAML.
+2. `TEST workflow` with `{}` inputs or realistic input values.
+3. If test execution fails, inspect the returned validation or runtime error.
+4. Fix YAML and test again.
+5. Only persist with `CREATE workflow` once the test path works.
+6. `RUN workflow`, then inspect execution details and logs.
+
+For YAML with complex shell quoting, write a temporary JSON command input file and use `--input-file`. This is safer than
+passing multi-line YAML directly on the command line.
+
+Example command input for testing an unsaved YAML draft:
+
+```json
+{
+  "workflowYaml": "version: '1'\nname: Manual Hello Workflow\ntriggers:\n  - type: manual\nsteps:\n  - name: log_hello\n    type: console\n    with:\n      message: \"Hello world\"",
+  "inputs": {}
+}
+```
+
+Then run:
+
+```bash
+elastic stack kb workflows post-workflows-test --input-file /tmp/workflow-test.json
+```
+
+## References
+
+- [Workflow YAML Reference](references/workflow_yaml_reference.md) - root schema, triggers, step patterns, Liquid, and
+  API lifecycle
+- [Workflow Generation Tips](references/generation_tips.md) - syntax rules, validation strategy, common failures
+- [Workflow Patterns](references/workflow_patterns.md) - natural language patterns mapped to workflow YAML
+- [Demo Test Loop](references/demo_test_loop.md) - repeatable local PoC prompt and command sequence
+
+## Operations
+
+The body of this skill references workflow operations in shorthand form. How you run them depends on the environment:
+
+- **Direct shell / Claude:** run the `elastic` CLI commands in the table below.
+- **Agent Builder (CLI exposed as an MCP server):** there is no shell. Use the MCP tools `discover` → `man` → `exec`.
+  Do **not** call `elastic --help` or `elastic help`; the MCP wrapper only accepts real API commands and rejects help
+  invocations. To list commands, call `discover` with `surface: "kb"`, `query: "workflow"`. The command IDs are
+  dot-path form **without** a `stack.` prefix, e.g. `kb.workflows.post-workflows-test`. Fetch a command's input schema
+  with `man` (`id: "kb.workflows.post-workflows-test"`), then run it with `exec`:
+
+  ```json
+  {
+    "id": "kb.workflows.post-workflows-test",
+    "input": {
+      "workflowYaml": "version: '1'\nname: Manual Hello Workflow\ntriggers:\n  - type: manual\nsteps:\n  - name: log_hello\n    type: console\n    with:\n      message: \"Hello world\"",
+      "inputs": {}
+    }
+  }
+  ```
+
+  Note: `inputs` is required for `post-workflows-test`. `exec` input keys match the `man` schema (e.g. `workflowYaml`,
+  not snake_case). Map the shorthand operations to MCP IDs by replacing `elastic stack kb workflows <cmd>` with
+  `kb.workflows.<cmd>`.
+
+When running the shell CLI, note that read-only `get-` commands may fail with `EAGAIN: resource temporarily unavailable`
+if the shell leaves stdin open; append `</dev/null` to those commands (for example
+`... get-workflows-executions-executionid --execution-id "{id}" --include-output true </dev/null`).
+
+| Operation | `elastic` CLI command |
+| --- | --- |
+| `STATUS` | `elastic es info` |
+| `LIST workflows` | `elastic stack kb workflows get-workflows` |
+| `GET workflow` | `elastic stack kb workflows get-workflows-workflow-id --id "{workflowId}"` |
+| `TEST workflow` | `elastic stack kb workflows post-workflows-test --input-file /tmp/workflow-test.json` |
+| `CREATE workflow` | `elastic stack kb workflows post-workflows-workflow --input-file /tmp/workflow-create.json` |
+| `UPDATE workflow` | `elastic stack kb workflows put-workflows-workflow-id --id "{workflowId}" --input-file /tmp/workflow-update.json` |
+| `RUN workflow` | `elastic stack kb workflows post-workflows-workflow-id-run --id "{workflowId}" --inputs "{}"` |
+| `GET execution` | `elastic stack kb workflows get-workflows-executions-executionid --execution-id "{executionId}" --include-output true` |
+| `GET logs` | `elastic stack kb workflows get-workflows-executions-executionid-logs --execution-id "{executionId}" --size 100` |
+| `GET schema` | `elastic stack kb workflows get-workflows-schema --loose true` |
+| `TEST step` | `elastic stack kb workflows post-workflows-step-test --input-file /tmp/workflow-step-test.json` |
+
+For `CREATE workflow`, prefer an input file shaped like:
+
+```json
+{
+  "id": "manual-hello-workflow",
+  "yaml": "version: '1'\nname: Manual Hello Workflow\ntriggers:\n  - type: manual\nsteps:\n  - name: log_hello\n    type: console\n    with:\n      message: \"Hello world\""
+}
+```
+
+For `RUN workflow`, pass inputs as JSON:
+
+```bash
+elastic stack kb workflows post-workflows-workflow-id-run --id "manual-hello-workflow" --inputs '{"name":"world"}'
+```

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/workflows/references/demo_test_loop.md
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/workflows/references/demo_test_loop.md
@@ -1,0 +1,87 @@
+# Demo Test Loop
+
+Use this as the minimal repeatable demo for the universal `kibana-workflows` skill.
+
+## Prompt
+
+```text
+Use the kibana-workflows skill. Create a simple manual workflow named "Manual Hello Workflow" that accepts a `name`
+input and logs `Hello {{ inputs.name }}`. Test it with the elastic CLI, then show me the create/run/log commands I can
+reuse.
+```
+
+## Expected YAML Draft
+
+```yaml
+version: '1'
+name: Manual Hello Workflow
+description: Logs a greeting from a manual workflow
+enabled: true
+tags: ["demo", "workflow"]
+
+triggers:
+  - type: manual
+
+inputs:
+  properties:
+    name:
+      type: string
+      description: Name to greet
+      default: "world"
+
+steps:
+  - name: log_hello
+    type: console
+    with:
+      message: "Hello {{ inputs.name }}"
+```
+
+## Test Unsaved YAML
+
+Write a JSON input file. Prefer JSON files for CLI invocations so multi-line YAML does not depend on shell quoting.
+
+```json
+{
+  "workflowYaml": "version: '1'\nname: Manual Hello Workflow\ndescription: Logs a greeting from a manual workflow\nenabled: true\ntags: [\"demo\", \"workflow\"]\n\ntriggers:\n  - type: manual\n\ninputs:\n  properties:\n    name:\n      type: string\n      description: Name to greet\n      default: \"world\"\n\nsteps:\n  - name: log_hello\n    type: console\n    with:\n      message: \"Hello {{ inputs.name }}\"",
+  "inputs": {
+    "name": "Shahar"
+  }
+}
+```
+
+Run:
+
+```bash
+elastic stack kb workflows post-workflows-test --input-file /tmp/manual-hello-test.json
+```
+
+## Create Workflow
+
+```json
+{
+  "id": "manual-hello-workflow",
+  "yaml": "version: '1'\nname: Manual Hello Workflow\ndescription: Logs a greeting from a manual workflow\nenabled: true\ntags: [\"demo\", \"workflow\"]\n\ntriggers:\n  - type: manual\n\ninputs:\n  properties:\n    name:\n      type: string\n      description: Name to greet\n      default: \"world\"\n\nsteps:\n  - name: log_hello\n    type: console\n    with:\n      message: \"Hello {{ inputs.name }}\""
+}
+```
+
+Run:
+
+```bash
+elastic stack kb workflows post-workflows-workflow --input-file /tmp/manual-hello-create.json
+```
+
+## Run And Inspect
+
+```bash
+elastic stack kb workflows post-workflows-workflow-id-run --id "manual-hello-workflow" --inputs '{"name":"Shahar"}'
+elastic stack kb workflows get-workflows-executions-executionid --execution-id "{executionId}" --include-output true
+elastic stack kb workflows get-workflows-executions-executionid-logs --execution-id "{executionId}" --size 100
+```
+
+## Success Criteria
+
+- Agent Builder loads `kibana-workflows` as a markdown universal skill.
+- The loaded skill includes references for syntax, generation tips, patterns, and this demo loop.
+- The generated YAML uses `version: '1'`, a manual trigger, valid `inputs.properties`, and a `console` step.
+- The workflow is validated or test-run through `elastic stack kb workflows post-workflows-test`.
+- The final answer shows the exact CLI commands for create, run, execution details, and logs.

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/workflows/references/generation_tips.md
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/workflows/references/generation_tips.md
@@ -1,0 +1,142 @@
+# Workflow Generation Tips
+
+Guidelines for translating natural language into valid Elastic Workflow YAML.
+
+## Generation Process
+
+1. **Classify the trigger.**
+   - "Run this now", "on demand", "manual" -> `manual`
+   - "Every hour", "daily", "periodically" -> `scheduled`
+   - "When an alert fires", "from a detection rule" -> `alert`
+
+2. **Identify inputs and constants.**
+   - Values users provide at run time belong in `inputs`.
+   - Fixed values such as index patterns, thresholds, or connector names belong in `consts`.
+
+3. **Choose the smallest step sequence.**
+   - Start with `console` for simple demos.
+   - Use `elasticsearch.search` or `elasticsearch.esql.query` for data lookup.
+   - Use `data.set` / `data.transform` before conditions when a computed value is needed.
+   - Use connector steps for external systems.
+
+4. **Write YAML with explicit data flow.**
+   - Give each step a stable snake_case `name`.
+   - Reference prior step outputs through `steps.<name>.output`.
+   - Use `foreach.item` only inside `foreach` child steps.
+
+5. **Test early.**
+   - Use `post-workflows-test` before persisting when possible.
+   - If a workflow must be persisted first, create it disabled or safe, then run with minimal inputs.
+
+## Critical Syntax Rules
+
+### Include The Workflow Version
+
+Always include:
+
+```yaml
+version: '1'
+```
+
+### Use `event`, Not `triggers.event`
+
+The `triggers` block configures activation. Runtime data is available as `event`.
+
+```yaml
+# WRONG
+message: "{{ triggers.event.rule.name }}"
+
+# CORRECT
+message: "{{ event.rule.name }}"
+```
+
+### Step Outputs Use `.output`
+
+```yaml
+# WRONG
+message: "{{ steps.search.with.query }}"
+
+# CORRECT
+message: "{{ steps.search.output.hits.total.value }}"
+```
+
+### `if` Step Conditions Are KQL-Like, Not Liquid
+
+Do not put Liquid filters directly in an `if` step's `condition`.
+
+```yaml
+# WRONG
+- name: check
+  type: if
+  condition: "{{ steps.search.output.hits | size }} > 0"
+
+# BETTER
+- name: set_count
+  type: data.set
+  with:
+    count: "{{ steps.search.output.hits.hits | size }}"
+- name: check
+  type: if
+  condition: "steps.set_count.output.count > 0"
+```
+
+### Connector Steps Need `connector-id`
+
+```yaml
+- name: notify
+  type: slack
+  connector-id: my-slack-connector
+  with:
+    message: "Done"
+```
+
+If the connector ID is unknown, ask the user or use a placeholder that is clearly marked.
+
+### Step Config Does Not Always Belong In `with`
+
+For `if` and `foreach`, child steps and control fields are step-level config:
+
+```yaml
+- name: for_each_alert
+  type: foreach
+  foreach: "{{ event.alerts }}"
+  steps:
+    - name: log_alert
+      type: console
+      with:
+        message: "{{ foreach.item._id }}"
+```
+
+## Validation Strategy
+
+Prefer this loop:
+
+1. Generate YAML.
+2. Build `/tmp/workflow-test.json` with `workflowYaml` and `inputs`.
+3. Run:
+
+   ```bash
+   elastic stack kb workflows post-workflows-test --input-file /tmp/workflow-test.json
+   ```
+
+4. If validation fails, fix all occurrences of the same mistake before retrying.
+5. If runtime fails, inspect execution/logs and fix the step that failed.
+
+## Repair Heuristics
+
+| Error shape | Likely fix |
+| --- | --- |
+| Unknown step type | Use a built-in type or connector type known to exist |
+| Missing required property | Move the field into `with` or add required step config |
+| Liquid variable resolves empty | Check `steps.<name>.output` path or `event` availability |
+| Manual run has no alert data | Add inputs or guard alert-only branches |
+| Connector step fails before execution | Add or correct `connector-id` |
+| Query step returns no useful data | Loosen filters, validate index/field names, or use sample output |
+
+## Safe Defaults
+
+- Use `manual` trigger for the first draft.
+- Use `console` output in demos before adding side effects.
+- Prefer read-only Elasticsearch queries before writes.
+- Add `enabled: true` only when the user wants the workflow runnable from triggers.
+- Ask before creating workflows that send notifications, write documents, or call external services.

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/workflows/references/workflow_patterns.md
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/workflows/references/workflow_patterns.md
@@ -1,0 +1,170 @@
+# Workflow Patterns
+
+Common natural-language requests and the workflow shapes they imply.
+
+## Manual Demo Workflow
+
+User says:
+
+- "Create a simple workflow"
+- "Make a workflow that logs hello"
+- "Show me the fastest end-to-end workflow"
+
+Use:
+
+```yaml
+version: '1'
+name: Manual Hello Workflow
+enabled: true
+triggers:
+  - type: manual
+steps:
+  - name: log_hello
+    type: console
+    with:
+      message: "Hello from workflow"
+```
+
+This is the best first smoke test because it has no external dependencies.
+
+## Scheduled Report
+
+User says:
+
+- "Every hour, check..."
+- "Run daily and summarize..."
+- "Generate a periodic report..."
+
+Use:
+
+```yaml
+version: '1'
+name: Scheduled Health Report
+enabled: true
+triggers:
+  - type: scheduled
+    with:
+      every: "1h"
+steps:
+  - name: query_data
+    type: elasticsearch.esql.query
+    with:
+      query: "FROM logs-* | WHERE @timestamp > NOW() - 1 hour | STATS count = COUNT(*)"
+  - name: log_summary
+    type: console
+    with:
+      message: "Query result: {{ steps.query_data.output | json }}"
+```
+
+Validate index names and field names before relying on this in a real environment.
+
+## Alert Triage
+
+User says:
+
+- "When a critical alert fires..."
+- "For each alert, enrich it..."
+- "Create a case from alerts..."
+
+Use an alert trigger and `event.alerts`:
+
+```yaml
+version: '1'
+name: Alert Triage Workflow
+enabled: true
+triggers:
+  - type: alert
+steps:
+  - name: log_alerts
+    type: console
+    with:
+      message: "Received {{ event.alerts | size }} alerts from {{ event.rule.name }}"
+  - name: process_alerts
+    type: foreach
+    foreach: "{{ event.alerts }}"
+    steps:
+      - name: log_alert
+        type: console
+        with:
+          message: "Alert {{ foreach.item._id }} in {{ foreach.item._index }}"
+```
+
+If the same workflow must also run manually, add inputs or guard alert-only branches because manual runs do not have
+`event.alerts`.
+
+## Connector Notification
+
+User says:
+
+- "Send to Slack"
+- "Create a Jira ticket"
+- "Email the summary"
+
+Use a connector step and require a connector ID:
+
+```yaml
+version: '1'
+name: Notify Slack Workflow
+enabled: true
+triggers:
+  - type: manual
+steps:
+  - name: send_slack
+    type: slack
+    connector-id: my-slack-connector
+    with:
+      message: "Workflow completed"
+```
+
+If connector ID is unknown, do not invent a real one. Ask the user or use a placeholder in a draft.
+
+## Query Then Branch
+
+User says:
+
+- "If there are any errors..."
+- "Only notify when count is greater than..."
+- "Create a case when the query returns results..."
+
+Use a query, compute a simple value, then branch:
+
+```yaml
+version: '1'
+name: Query Then Branch
+enabled: true
+triggers:
+  - type: manual
+steps:
+  - name: find_errors
+    type: elasticsearch.esql.query
+    with:
+      query: "FROM logs-* | WHERE @timestamp > NOW() - 1 hour | WHERE log.level == \"error\" | STATS errors = COUNT(*)"
+  - name: set_error_count
+    type: data.set
+    with:
+      count: "{{ steps.find_errors.output.values[0][0] | default: 0 }}"
+  - name: has_errors
+    type: if
+    condition: "steps.set_error_count.output.count > 0"
+    steps:
+      - name: log_errors
+        type: console
+        with:
+          message: "Errors found: {{ steps.set_error_count.output.count }}"
+    else:
+      - name: log_clean
+        type: console
+        with:
+          message: "No errors found"
+```
+
+Output shape for query steps can vary by step implementation. Test-run before depending on an exact path.
+
+## Local Test Cycle
+
+For any pattern, first prove a safe version:
+
+1. Replace side-effecting connector or HTTP steps with `console` steps.
+2. Run `TEST workflow`.
+3. Inspect output/logs.
+4. Restore the side-effecting step once the control flow is correct.

--- a/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/workflows/references/workflow_yaml_reference.md
+++ b/x-pack/platform/plugins/shared/agent_builder_platform/server/skills/workflows/references/workflow_yaml_reference.md
@@ -1,0 +1,207 @@
+# Workflow YAML Reference
+
+Elastic Workflows are YAML documents executed by Kibana. They have metadata, triggers, optional inputs/constants, and an
+ordered `steps` array.
+
+## Root Structure
+
+```yaml
+version: '1'
+name: Workflow Name
+description: What this workflow does
+enabled: true
+tags: ["tag1", "tag2"]
+
+consts:
+  index: "logs-*"
+
+inputs:
+  properties:
+    severity:
+      type: string
+      description: Alert severity to process
+      default: "critical"
+
+triggers:
+  - type: manual
+
+steps:
+  - name: first_step
+    type: console
+    with:
+      message: "Workflow started"
+```
+
+## Triggers
+
+### Manual
+
+Use manual triggers for demos, testing, and user-initiated runs.
+
+```yaml
+triggers:
+  - type: manual
+```
+
+Manual runs do not have alert event context. If a workflow can run manually and from alerts, guard alert-only branches.
+
+### Scheduled
+
+Use scheduled triggers for recurring checks or reports.
+
+```yaml
+triggers:
+  - type: scheduled
+    with:
+      every: "1h"
+```
+
+### Alert
+
+Use alert triggers when a Kibana rule or Security detection should dispatch to the workflow.
+
+```yaml
+triggers:
+  - type: alert
+```
+
+Alert runtime data is available under `event`:
+
+- `{{ event.alerts }}` - array of alert documents
+- `{{ event.alerts[0]._id }}` - alert ID
+- `{{ event.alerts[0]._index }}` - alert index
+- `{{ event.alerts[0]["@timestamp"] }}` - alert timestamp
+- `{{ event.rule.name }}` - rule name
+- `{{ event.spaceId }}` - Kibana space
+
+Never use `triggers.event`, `trigger.event`, or `triggers.event.*`.
+
+## Inputs And Constants
+
+Use `consts` for fixed workflow configuration, and `inputs` for values passed at run time.
+
+```yaml
+consts:
+  target_index: "logs-*"
+
+inputs:
+  properties:
+    service_name:
+      type: string
+      description: Service to inspect
+```
+
+Reference them with Liquid:
+
+```yaml
+with:
+  message: "Checking {{ inputs.service_name }} in {{ consts.target_index }}"
+```
+
+## Step Fields
+
+Every step has:
+
+- `name`: unique within the workflow
+- `type`: step type ID or connector type
+- `with`: input parameters for the step type
+
+Common optional fields:
+
+- `connector-id`: connector instance ID for connector steps
+- `if`: skip this step unless the expression is truthy
+- `timeout`: step timeout
+- `on-failure`: retry, fallback, and continuation behavior
+
+Step config fields outside `with` depend on the step type:
+
+- `if` step: `condition`, `steps`, `else`
+- `foreach` step: `foreach`, `steps`
+
+## Built-In Step Types
+
+| Step type | Description |
+| --- | --- |
+| `console` | Log a message for debugging or demo output |
+| `elasticsearch.search` | Execute Elasticsearch Query DSL |
+| `elasticsearch.esql.query` | Execute ES|QL |
+| `elasticsearch.bulk` | Bulk index documents |
+| `data.set` | Store values in workflow context |
+| `data.transform` | Transform data |
+| `if` | Branch by KQL condition |
+| `foreach` | Iterate over a collection |
+| `wait` | Pause execution |
+| `http` | Make an HTTP request |
+| `ai.agent` | Invoke an Agent Builder agent |
+
+## Connector Steps
+
+Connector steps use the connector type as the step type and require a connector instance ID.
+
+```yaml
+- name: send_slack
+  type: slack
+  connector-id: my-slack-connector
+  with:
+    message: "Workflow completed"
+```
+
+Prefer connector steps for Slack, Jira, PagerDuty, email, ServiceNow, Teams, and similar integrations. Use raw `http`
+only when no connector exists or the user requests a custom HTTP API call.
+
+## Liquid Templating
+
+Use Liquid expressions for dynamic values:
+
+```yaml
+{{ inputs.input_name }}
+{{ consts.constant_name }}
+{{ steps.step_name.output.field }}
+{{ foreach.item }}
+{{ event }}
+```
+
+Useful filters:
+
+```yaml
+{{ data | json }}
+{{ value | default: "fallback" }}
+{{ text | url_encode }}
+{{ items | size }}
+```
+
+Only step outputs are addressable through `steps.<name>.output`. Step input parameters are not addressable through
+`steps.<name>.with.*`.
+
+## Error Handling
+
+Use `on-failure` for retries and fallback steps:
+
+```yaml
+- name: call_service
+  type: http
+  with:
+    method: GET
+    url: "https://example.com/status"
+  on-failure:
+    retry:
+      max-attempts: 3
+      delay: "10s"
+    fallback:
+      - name: log_failure
+        type: console
+        with:
+          message: "HTTP call failed"
+    continue: true
+```
+
+## Lifecycle
+
+Use the `elastic` CLI for the fast loop:
+
+1. Write YAML.
+2. `TEST workflow` with `post-workflows-test`.
+3. Fix validation/runtime errors.
+4. `CREATE workflow`.
+5. `RUN workflow`.
+6. Inspect execution and logs.


### PR DESCRIPTION
## Summary

Adds a Brandon-style **`kibana-workflows`** universal skill on top of the `esql-universal-skill` branch, so Agent Builder can turn natural language into Kibana Workflow YAML the same way the ES|QL universal skill works.

- New skill at `x-pack/platform/plugins/shared/agent_builder_platform/server/skills/workflows/` (`SKILL.md` + 4 references: `workflow_yaml_reference`, `generation_tips`, `workflow_patterns`, `demo_test_loop`).
- Mirrors the ES|QL pattern: markdown teaches syntax/generation; live validation/execution goes through the `elastic` CLI.
- Operations map to `elastic stack kb workflows ...`. The skill documents **both** execution surfaces:
  - **Claude / shell:** run the `elastic` CLI directly.
  - **Agent Builder:** the CLI exposed as an MCP server — use `discover` -> `man` -> `exec` (command IDs are `kb.workflows.*`, no `stack.` prefix; `exec` keys are camelCase, e.g. `workflowYaml`).
- Registered via `UniversalSkill.fromDirectory` in `register_skills.ts` and allow-listed in `allow_lists.ts`.

## Verification (local PoC)

- **Claude/CLI path:** generate YAML -> `post-workflows-test` -> inspect execution -> `status: completed`. Verified end-to-end against local Kibana.
- **Agent Builder path:** verified `discover`/`man`/`exec` against the local CLI MCP server (`elastic-mcp --transport http --port 4319`); `exec kb.workflows.post-workflows-test` returned a real `workflowExecutionId`.

## Notes

- PoC / not production: the CLI MCP bridge is intentionally hacky and may fail on complex cases.
- Excludes the local `@babel/helper-globals` bootstrap workaround (not part of the feature).

## Test plan

- [ ] Restart Kibana so `UniversalSkill.fromDirectory` re-reads `SKILL.md`.
- [ ] In Agent Builder, assign `discover`/`man`/`exec` (not just `cli`) from the CLI MCP connector to the agent.
- [ ] Run: "create a manual workflow that logs a message, test-run it, show the execution status."
- [ ] Confirm the agent follows `discover` -> `man` -> `exec` and the execution completes.

Made with [Cursor](https://cursor.com)